### PR TITLE
Add mdx file support, Heading Renders(prose:pasted), MDXRemote

### DIFF
--- a/content/posts/first-post.mdx
+++ b/content/posts/first-post.mdx
@@ -1,0 +1,28 @@
+---
+title: "First Post"
+date: "2025-05-19"
+slug: "hello-world"
+desc: "This would be the description of my blog post in short"
+quote: "SEEDS ARE AGAIN SOWN"
+---
+
+Welcome to my first blog post written in **Markdown**!
+
+# DOES THIS WORK ?
+
+## Team Members
+
+{" "}
+
+<table>
+  <tr>
+    <th>Name</th>
+    <th>Role</th>
+    <th>EXP</th>
+  </tr>
+  <tr>
+    <td>Alice</td>
+    <td>Engineer</td>
+    <td>3 yrs</td>
+  </tr>
+</table>

--- a/content/posts/hello-world.md
+++ b/content/posts/hello-world.md
@@ -3,6 +3,9 @@ title: "Hello World"
 date: "2025-05-18"
 slug: "hello-world"
 desc: "This would be the description of my blog post in short"
+quote: "SEEDS ARE SOWN"
 ---
 
 Welcome to my first blog post written in **Markdown**!
+
+# DOES THIS WORK ?

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,6 +112,95 @@
   --sidebar-ring: oklch(0.553 0.013 58.071);
 }
 
+/* VERCEL COPY PASTE */
+.prose .anchor {
+  @apply absolute invisible no-underline;
+
+  margin-left: -1em;
+  padding-right: 0.5em;
+  width: 80%;
+  max-width: 700px;
+  cursor: pointer;
+}
+
+.anchor:hover {
+  @apply visible;
+}
+
+.prose a {
+  @apply underline transition-all decoration-neutral-400 dark:decoration-neutral-600 underline-offset-2 decoration-[0.1em];
+}
+
+.prose .anchor:after {
+  @apply text-neutral-300 dark:text-neutral-700;
+  content: "#";
+}
+
+.prose *:hover > .anchor {
+  @apply visible;
+}
+
+.prose pre {
+  @apply bg-neutral-50 dark:bg-neutral-900 rounded-lg overflow-x-auto border border-neutral-200 dark:border-neutral-900 py-2 px-3 text-sm;
+}
+
+.prose code {
+  @apply px-1 py-0.5 rounded-lg;
+}
+
+.prose pre code {
+  @apply p-0;
+  border: initial;
+  line-height: 1.5;
+}
+
+.prose code span {
+  @apply font-medium;
+}
+
+.prose img {
+  /* Don't apply styles to next/image */
+  @apply m-0;
+}
+
+.prose p {
+  @apply my-4 text-neutral-800 dark:text-neutral-200;
+}
+
+.prose h1 {
+  @apply text-4xl font-medium tracking-tight mt-6 mb-2;
+}
+
+.prose h2 {
+  @apply text-xl font-medium tracking-tight mt-6 mb-2;
+}
+
+.prose h3 {
+  @apply text-xl font-medium tracking-tight mt-6 mb-2;
+}
+
+.prose h4 {
+  @apply text-lg font-medium tracking-tight mt-6 mb-2;
+}
+
+.prose strong {
+  @apply font-medium;
+}
+
+.prose ul {
+  @apply list-disc pl-6;
+}
+
+.prose ol {
+  @apply list-decimal pl-6;
+}
+
+.prose > :first-child {
+  /* Override removing top margin, causing layout shift */
+  margin-top: 1.25em !important;
+  margin-bottom: 1.25em !important;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,16 +1,14 @@
 import { getPostBySlug, getPostSlugs } from "@/lib/posts";
 import { notFound } from "next/navigation";
-import ReactMarkdown from "react-markdown";
-import rehypeSanitize from "rehype-sanitize";
 import { MDXRemote } from "next-mdx-remote/rsc";
 
 type Props = {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 };
 
 export async function generateStaticParams() {
   const slugs = getPostSlugs().map((slug) => ({
-    slug: slug.replace(".md", ""),
+    slug: slug.replace(/\.mdx?$/, ""),
   }));
   return slugs;
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -2,6 +2,8 @@ import { getPostBySlug, getPostSlugs } from "@/lib/posts";
 import { notFound } from "next/navigation";
 import ReactMarkdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
+import { MDXRemote } from "next-mdx-remote/rsc";
+
 type Props = {
   params: { slug: string };
 };
@@ -31,9 +33,10 @@ export default async function PostPage({ params }: Props) {
         <article className="col-span-3 border min-h-screen border-gray-300 rounded-lg p-6 bg-white dark:bg-zinc-900 shadow-sm prose dark:prose-invert max-w-none">
           <h1 className="text-3xl font-bold mb-4">{post.meta.title}</h1>
           <p className="text-sm text-gray-500 mb-6">{post.meta.date}</p>
-          <ReactMarkdown rehypePlugins={[rehypeSanitize]}>
-            {post.content}
-          </ReactMarkdown>
+          <blockquote className="border-l-4 border-gray-300 pl-4 italic mb-6">
+            {post.meta.quote}
+          </blockquote>
+          <MDXRemote source={post.content} />
         </article>
 
         {/* Right column: 20% */}


### PR DESCRIPTION
Supports .mdx & .md filetypes.
Prose is now working thanks to vercel's blog example.
Implemented MDXRemote, removed reactMarkdown.